### PR TITLE
[Fix] build error caused by submodule not cloned

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,9 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/GeoDaCenter/pygeoda/archive/v{{ version }}.tar.gz
-  sha256: a054ec22a39bd093aee1049416d56a37fb8640167cd3d2b827870afee2a6500e
+  git_url: https://github.com/GeoDaCenter/pygeoda.git
+  git_tag: v{{ version }}
+  git_submodules: true  
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,6 @@ package:
 source:
   git_url: https://github.com/GeoDaCenter/pygeoda.git
   git_tag: v{{ version }}
-  git_submodules: true  
 
 build:
   number: 0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
